### PR TITLE
Register mess in Tab

### DIFF
--- a/Configuration/Elements/TypoScript/Tabs.setupts
+++ b/Configuration/Elements/TypoScript/Tabs.setupts
@@ -16,10 +16,10 @@ lib.gridelements {
 			file = EXT:themes_gridelements/Resources/Private/Templates/Elements/Tabs.html
 		}
 		columns.0 {
-			renderObj =< tt_content
-			renderObj.stdWrap {
-				preCObject = LOAD_REGISTER
-				preCObject {
+		        renderObj = COA
+			renderObj{
+				10 = LOAD_REGISTER
+				10 { 
 					containerId.dataWrap = tab-content-{field:uid}
 					containerClasses {
 						dataWrap = tab-pane,{field:parentgrid_tx_themes_behaviour}
@@ -35,10 +35,12 @@ lib.gridelements {
 						}
 					}
 				}
-				outerWrap = <div role="tabpanel" id="{register:containerId}" class="{register:containerClasses}">|</div>
-				outerWrap.insertData = 1
+				20 =< tt_content
+				20.stdWrap.outerWrap = <div role="tabpanel" id="{register:containerId}" class="{register:containerClasses}">|</div>
+				20.stdWrap.outerWrap.insertData = 1
+				30 = RESTORE_REGISTER
 			}
-			renderObj.postCObject = RESTORE_REGISTER
+			
 		}
 	}
 }


### PR DESCRIPTION
Hi, 
Using precObject and postCObject to load and restore registers dosent fix the register mess problem. Maybe rendering order related REGISTER in stdWrap while restore not ?  So i have to handle it inside renderobj in order to ensure correct rendering order of LOAD and RESTORE.