### PR TITLE
Use property instead of name for author+publisher

### DIFF
--- a/Configuration/TypoScript/Library/page.meta.setupts
+++ b/Configuration/TypoScript/Library/page.meta.setupts
@@ -20,12 +20,14 @@ page.meta {
 	# author
 	author.data = levelfield :-1, author, slide
 	author.override.data = page:author
+	author.attribute = property
 	author.ifEmpty = {$themes.configuration.meta.defaults.author}
 	author.author = 1
 
 	# publisher
 	publisher.data = levelfield :-1, author, slide
 	publisher.override.data = page:author
+	publisher.attribute = property
 	publisher.ifEmpty = {$themes.configuration.meta.defaults.author}
 	publisher.publisher = 1
 


### PR DESCRIPTION
Fix sharing error in facebook debugger : The meta tag on the page was specified with name 'author', which matches a configured property of this object type. It will be ignored unless specified with the meta property attribute instead of the meta name attribute.

![screenshot-developers facebook com 2017-01-04 11-02-49](https://cloud.githubusercontent.com/assets/7780497/21638826/56d22bce-d26d-11e6-8f51-859641b16387.png)
