### PR TITLE
[TASK] Update dependency gridelements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,6 @@
   },
   "require": {
     "typo3-themes/themes": "~8.7.0",
-    "GridElementsTeam/Gridelements": "dev-master"
+    "GridElementsTeam/Gridelements": "~8.0"
   }
 }


### PR DESCRIPTION
Now EXT:gridelements is tagged for TYPO3 CMS 8