### PR TITLE
[TASK] Migrate config for html tag

### DIFF
--- a/Configuration/TypoScript/Library/config.typoscript
+++ b/Configuration/TypoScript/Library/config.typoscript
@@ -5,7 +5,7 @@ removeDefaultJS = 1
 config {
 
 	# Preparing modernizr usage
-	htmlTag_setParams = class="no-js no-skrollr" lang="{$themes.languages.current.isoCodeHtml}"
+	htmlTag.attributes.class = no-js no-skrollr
 
 	# Set the baseurl
 	# as baseURL is deprecated, we do not set this anymore!


### PR DESCRIPTION
At TYPO3 12 in the HTML tag the attribute "lang" is no longer output correctly. Since this is now integrated in the core via the siteconfiguration, the TypoScript configuration was changed and only the class attribute was adapted.

Since I am not sure whether further language-specific adjustments are necessary, here is a pull request.